### PR TITLE
README.md: fix screenshot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/catppuccin/foot-catppuccin/main/assets/foot.png"/>
+  <img src="https://raw.githubusercontent.com/catppuccin/foot/main/assets/foot.png"/>
 </p>
 
 ## Usage


### PR DESCRIPTION
The screenshot in README.md currently doesn't load because the screenshot path is wrong