### PR TITLE
fix: cursor.color is now deprecated, use colors.cursor instead.

### DIFF
--- a/foot.tera
+++ b/foot.tera
@@ -5,9 +5,6 @@ whiskers:
     - flavor
   filename: "themes/catppuccin-{{flavor.identifier}}.ini"
 ---
-[cursor]
-color={% if flavor.dark %}{{ crust.hex }}{% else %}{{ base.hex }}{% endif %} {{rosewater.hex}}
-
 [colors]
 {#
   0 = black
@@ -19,6 +16,7 @@ color={% if flavor.dark %}{{ crust.hex }}{% else %}{{ base.hex }}{% endif %} {{r
   6 = cyan
   7 = white
 -#}
+cursor={% if flavor.dark %}{{ crust.hex }}{% else %}{{ base.hex }}{% endif %} {{rosewater.hex}}
 foreground={{text.hex}}
 background={{base.hex}}
 

--- a/themes/catppuccin-frappe.ini
+++ b/themes/catppuccin-frappe.ini
@@ -1,7 +1,5 @@
-[cursor]
-color=232634 f2d5cf
-
 [colors]
+cursor=232634 f2d5cf
 foreground=c6d0f5
 background=303446
 

--- a/themes/catppuccin-latte.ini
+++ b/themes/catppuccin-latte.ini
@@ -1,7 +1,5 @@
-[cursor]
-color=eff1f5 dc8a78
-
 [colors]
+cursor=eff1f5 dc8a78
 foreground=4c4f69
 background=eff1f5
 

--- a/themes/catppuccin-macchiato.ini
+++ b/themes/catppuccin-macchiato.ini
@@ -1,7 +1,5 @@
-[cursor]
-color=181926 f4dbd6
-
 [colors]
+cursor=181926 f4dbd6
 foreground=cad3f5
 background=24273a
 

--- a/themes/catppuccin-mocha.ini
+++ b/themes/catppuccin-mocha.ini
@@ -1,7 +1,5 @@
-[cursor]
-color=11111b f5e0dc
-
 [colors]
+cursor=11111b f5e0dc
 foreground=cdd6f4
 background=1e1e2e
 


### PR DESCRIPTION
Since 1.23.0, [cursor.color is deprecated](https://codeberg.org/dnkl/foot/releases/tag/1.23.0#user-content-deprecated).