### PR TITLE
fix: colors is now deprecated, use colors-dark instead.

### DIFF
--- a/foot.tera
+++ b/foot.tera
@@ -5,7 +5,7 @@ whiskers:
     - flavor
   filename: "themes/catppuccin-{{flavor.identifier}}.ini"
 ---
-[colors]
+[colors-dark]
 {#
   0 = black
   1 = red

--- a/themes/catppuccin-frappe.ini
+++ b/themes/catppuccin-frappe.ini
@@ -1,4 +1,4 @@
-[colors]
+[colors-dark]
 cursor=232634 f2d5cf
 foreground=c6d0f5
 background=303446

--- a/themes/catppuccin-latte.ini
+++ b/themes/catppuccin-latte.ini
@@ -1,4 +1,4 @@
-[colors]
+[colors-dark]
 cursor=eff1f5 dc8a78
 foreground=4c4f69
 background=eff1f5

--- a/themes/catppuccin-macchiato.ini
+++ b/themes/catppuccin-macchiato.ini
@@ -1,4 +1,4 @@
-[colors]
+[colors-dark]
 cursor=181926 f4dbd6
 foreground=cad3f5
 background=24273a

--- a/themes/catppuccin-mocha.ini
+++ b/themes/catppuccin-mocha.ini
@@ -1,4 +1,4 @@
-[colors]
+[colors-dark]
 cursor=11111b f5e0dc
 foreground=cdd6f4
 background=1e1e2e


### PR DESCRIPTION
Since [1.26.0](https://codeberg.org/dnkl/foot/releases/tag/1.26.0), [colors-dark] section to foot.ini. replaces [colors]